### PR TITLE
remove obsolete input and pass-through of audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ module "aws_dynamic_provider_credentials" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_tfc_aws_audience"></a> [tfc\_aws\_audience](#input\_tfc\_aws\_audience) | AWS audience | `string` | `"aws.workload.identity"` | no |
 | <a name="input_tfc_hostname"></a> [tfc\_hostname](#input\_tfc\_hostname) | The hostname of the TFC or TFE instance you'd like to use with AWS | `string` | `"app.terraform.io"` | no |
 | <a name="input_tfc_organization"></a> [tfc\_organization](#input\_tfc\_organization) | Name of the organization | `string` | n/a | yes |
 | <a name="input_tfc_project"></a> [tfc\_project](#input\_tfc\_project) | Name of the terraform cloud/enterprise project | `string` | n/a | yes |
@@ -112,7 +111,6 @@ module "aws_dynamic_provider_credentials" {
 
 | Name | Description |
 |------|-------------|
-| <a name="output_aws_tfc_audience"></a> [aws\_tfc\_audience](#output\_aws\_tfc\_audience) | n/a |
 | <a name="output_full_names"></a> [full\_names](#output\_full\_names) | A list of all 'full\_name' values |
 | <a name="output_oidc_claims"></a> [oidc\_claims](#output\_oidc\_claims) | A map of 'full\_name' as key and 'openid\_claims' as value |
 | <a name="output_role_arns"></a> [role\_arns](#output\_role\_arns) | A map of 'full\_name' as key and 'role\_arn' as value |

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,6 @@
 module "aws_identity_provider" {
   source           = "./modules/iam_identity_provider"
   tfc_organization = var.tfc_organization
-  tfc_aws_audience = var.tfc_aws_audience
   tfc_hostname     = var.tfc_hostname
 }
 

--- a/modules/iam_identity_provider/README.md
+++ b/modules/iam_identity_provider/README.md
@@ -10,7 +10,6 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.32.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.5 |
 
 ## Modules
@@ -22,15 +21,12 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_openid_connect_provider.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
-| [random_string.sfx1](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [random_string.sfx2](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [tls_certificate.tfc_certificate](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_tfc_aws_audience"></a> [tfc\_aws\_audience](#input\_tfc\_aws\_audience) | The audience value to use in run identity tokens | `string` | `"aws.workload.identity"` | no |
 | <a name="input_tfc_hostname"></a> [tfc\_hostname](#input\_tfc\_hostname) | The hostname of the TFC or TFE instance you'd like to use with AWS | `string` | `"app.terraform.io"` | no |
 | <a name="input_tfc_organization"></a> [tfc\_organization](#input\_tfc\_organization) | The name of the TFC or TFE organization you'd like to use with AWS | `string` | n/a | yes |
 
@@ -40,5 +36,4 @@ No modules.
 |------|-------------|
 | <a name="output_aws_oidc_tfc_provider_arn"></a> [aws\_oidc\_tfc\_provider\_arn](#output\_aws\_oidc\_tfc\_provider\_arn) | The ARN of the AWS IAM OIDC Identity Provider created for TFC |
 | <a name="output_aws_oidc_tfc_provider_client_id_list"></a> [aws\_oidc\_tfc\_provider\_client\_id\_list](#output\_aws\_oidc\_tfc\_provider\_client\_id\_list) | The list of client IDs for the AWS IAM OIDC Identity Provider created for TFC |
-| <a name="output_aws_tfc_audience"></a> [aws\_tfc\_audience](#output\_aws\_tfc\_audience) | The audience for the AWS IAM OIDC Identity Provider created for TFC |
 <!-- END_TF_DOCS -->

--- a/modules/iam_identity_provider/main.tf
+++ b/modules/iam_identity_provider/main.tf
@@ -3,21 +3,9 @@ data "tls_certificate" "tfc_certificate" {
   url = "https://${var.tfc_hostname}"
 }
 
-// generate two random strings to use as audience
-resource "random_string" "sfx1" {
-  length  = 5
-  special = false
-  upper   = false
-}
-resource "random_string" "sfx2" {
-  length  = 3
-  special = false
-  upper   = false
-}
-
 // create AWS IAM OIDC Identity Provider
 resource "aws_iam_openid_connect_provider" "this" {
   url             = data.tls_certificate.tfc_certificate.url
-  client_id_list  = [var.tfc_aws_audience]
+  client_id_list  = ["aws.workload.identity"]
   thumbprint_list = [data.tls_certificate.tfc_certificate.certificates[0].sha1_fingerprint]
 }

--- a/modules/iam_identity_provider/outputs.tf
+++ b/modules/iam_identity_provider/outputs.tf
@@ -7,9 +7,3 @@ output "aws_oidc_tfc_provider_client_id_list" {
   value       = aws_iam_openid_connect_provider.this.client_id_list
   description = "The list of client IDs for the AWS IAM OIDC Identity Provider created for TFC"
 }
-
-output "aws_tfc_audience" {
-  value       = var.tfc_aws_audience
-  description = "The audience for the AWS IAM OIDC Identity Provider created for TFC"
-  sensitive   = true
-}

--- a/modules/iam_identity_provider/variables.tf
+++ b/modules/iam_identity_provider/variables.tf
@@ -8,9 +8,3 @@ variable "tfc_organization" {
   type        = string
   description = "The name of the TFC or TFE organization you'd like to use with AWS"
 }
-
-variable "tfc_aws_audience" {
-  type        = string
-  default     = "aws.workload.identity"
-  description = "The audience value to use in run identity tokens"
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,8 +12,3 @@ output "role_arns" {
   value       = { for instance in module.aws_tfc_dynamic_credentials_iam_roles : instance.full_name => instance.role_arn }
   description = "A map of 'full_name' as key and 'role_arn' as value"
 }
-
-output "aws_tfc_audience" {
-  value     = module.aws_identity_provider.aws_tfc_audience
-  sensitive = true
-}

--- a/variables.tf
+++ b/variables.tf
@@ -7,12 +7,6 @@ variable "tfc_organization" {
   description = "Name of the organization"
 }
 
-variable "tfc_aws_audience" {
-  type        = string
-  description = "AWS audience"
-  default     = "aws.workload.identity"
-}
-
 variable "tfc_hostname" {
   type        = string
   default     = "app.terraform.io"


### PR DESCRIPTION
# Description

Removes ineffective input `tfc_aws_audience` and replaces `aws_iam_openid_connect_provider.this.client_id_list` with the only value used globally: `aws.workload.identity`.

Related boilerplate resources `random_string.sfx1` and `random_string.sfx2` removed as well.

## How Has This Been Tested?

1. `terraform validate`
2. Search over both orgs
    * org:urbanmedia audience
    * org:tagesspiegel audience

No functional use. Only IaC-terraform-cloud passes the output through which needs removal. This constitutes a breaking change.

**Test Configuration**:

- Terraform version: 1.9.2
- Module version:

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
